### PR TITLE
Update README with docker logs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ docker compose restart control-center
 docker compose stop
 ```
 
+## Docker commands
+
+### Monitor logs in Kafka Connect container
+
+```bash
+docker logs -f connect
+```
+
 ## UI
 
 ### Control Center


### PR DESCRIPTION
Kafka Connect can fail when a poison pill enters the Kafka topic. It would help troubleshoot by accessing the log

In this PR, Update README with docker logs command